### PR TITLE
fix(git/config): remove unnecessary indentation

### DIFF
--- a/dot_config/git/config
+++ b/dot_config/git/config
@@ -8,7 +8,7 @@
 	autocrlf = input
 [commit]
 	verbose = true
-	[interactive]
+[interactive]
 	diffFilter = delta --color-only
 [delta]
 	navigate = true


### PR DESCRIPTION
imo, all sections in the square brackets should start from the beginning of the file, as the `git config` command would do.

as [git manual](https://git-scm.com/docs/git-config#_configuration_file) says, the config file mostly ignores all blank lines and whitespaces, but i think it's a good practice to stay consistent. also, this syntax can be misleading and recognized as a subsection (it is not).

and one more thing: is the config correct? `interactive.diffFilter` uses `delta` as the command to show the diff, but the `core.pager` value is unset. is this intentional? 